### PR TITLE
Implement SQL Compiler, Performance Optimizations, and Documentation Updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,9 +10,8 @@ This repository provides a Rust implementation of the [CEL](https://github.com/g
 - Follow standard Rust naming conventions (`snake_case` for functions/variables, `CamelCase` for types).
 
 ## Testing
-- Run the full Rust test suite before committing:
-  - `cargo +nightly-2025-08-08 test`
-  - `cargo +nightly-2025-08-08 test --no-default-features`
+- Before committing, run the complete test suite with `make run-all-tests`.
+- The repository's `rust-toolchain.toml` pins the nightly toolchain, so `cargo test` automatically uses the correct version.
 - If your changes affect the Python bindings or tests, rebuild the wheel and run the Python tests:
   - `make run-python-tests`
 - For WebAssembly changes, run `make run-wasm-tests`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# Agent Guidelines
+
+## Overview
+This repository provides a Rust implementation of the [CEL](https://github.com/google/cel-spec) language with optional Python and WebAssembly bindings.
+
+## Coding Standards
+- Use Rust 2021 edition and the nightly toolchain defined in `rust-toolchain.toml`.
+- Format all Rust code with `cargo fmt --all` (automatically uses the pinned nightly toolchain).
+- Keep module and item documentation using Rust doc comments (`//!` for modules, `///` for items).
+- Follow standard Rust naming conventions (`snake_case` for functions/variables, `CamelCase` for types).
+
+## Testing
+- Run the full Rust test suite before committing:
+  - `cargo +nightly-2025-08-08 test`
+  - `cargo +nightly-2025-08-08 test --no-default-features`
+- If your changes affect the Python bindings or tests, rebuild the wheel and run the Python tests:
+  - `make run-python-tests`
+- For WebAssembly changes, run `make run-wasm-tests`.
+
+## Misc
+- The project targets sandboxed, bindable evaluation of user-provided CEL expressions; keep changes consistent with this design.
+

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,130 @@
+# Code of Conduct
+
+This project adopts the [Contributor Covenant](https://www.contributor-covenant.org) Code of Conduct to foster an open and welcoming community.
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+rscel-maintainers@example.com. All complaints will be reviewed and investigated
+promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+<https://www.contributor-covenant.org/faq>. Translations are available at
+<https://www.contributor-covenant.org/translations>.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing to rscel
+
+Thank you for your interest in contributing!
+
+## Filing Issues
+
+* Check the existing issues to see if your problem has already been reported.
+* Open a new issue with a clear description of the problem and steps to reproduce it.
+* If you have a feature request, explain the motivation and possible alternatives.
+
+## Running Tests
+
+Before submitting changes, make sure the test suite passes.
+
+```sh
+cargo +nightly-2025-08-08 test
+cargo +nightly-2025-08-08 test --no-default-features
+```
+
+If your change touches the Python bindings or WebAssembly support, also run:
+
+```sh
+make run-python-tests
+make run-wasm-tests
+```
+
+## Submitting Patches
+
+1. Fork the repository and create a topic branch for your changes.
+2. Ensure your code is formatted with `cargo fmt --all`.
+3. Commit your changes with clear messages.
+4. Open a pull request describing your changes and why they are needed.
+5. Be ready to address review feedback.
+
+We appreciate your contributions!
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ version = "1.0.6"
 edition = "2021"
 description = "Cel interpreter in rust"
 license = "MIT"
+repository = "https://github.com/1BADragon/rscel"
 
 [profile.release-with-debug]
 inherits = "release"

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ let mut exec_ctx = BindContext::new();
 ctx.add_program_str("main", "p.x + 3").unwrap();
 exec_ctx.bind_protobuf_msg("p", p);
 
-assert_eq!(ctx.exec("main", &exec_ctx), 7.into());
+assert_eq!(ctx.exec("main", &exec_ctx).unwrap(), 7.into());
   
 ```
 

--- a/README.md
+++ b/README.md
@@ -55,3 +55,12 @@ assert_eq!(ctx.exec("main", &exec_ctx).unwrap(), 7.into());
 ```
 
 Build status: [![Rust](https://github.com/1BADragon/rscel/actions/workflows/rust.yml/badge.svg)](https://github.com/1BADragon/rscel/actions/workflows/rust.yml)
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for how to file issues, run tests, and submit patches.
+
+## Code of Conduct
+
+This project adheres to the [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.
+

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # rscel
 
-RsCel is a CEL evaluator written in Rust. CEL is a google project that
+RsCel is a CEL evaluator written in Rust. CEL is a Google project that
 describes a turing-incomplete language that can be used to evaluate
-a user provdided expression. The language specification can be found
+a user provided expression. The language specification can be found
 [here](https://github.com/google/cel-spec/blob/master/doc/langdef.md).
 
-The design goals of this project were are as follows:
+The design goals of this project are as follows:
   * Flexible enough to allow for a user to bend the spec if needed
-  * Sandbox'ed in such a way that only specific values can be bound
-  * Can be used as a wasm depenedency (or other ffi)
+  * Sandboxed in such a way that only specific values can be bound
+  * Can be used as a wasm dependency (or other ffi)
 
 The basic example of how to use:
 ```rust
@@ -24,7 +24,7 @@ let res = ctx.exec("main", &exec_ctx).unwrap(); // CelValue::Int(6)
 assert_eq!(res, 6.into());
 ```
 
-As of 0.10.0 binding protobuf messages from the protobuf crate is now available! Given 
+Binding protobuf messages from the protobuf crate is available! Given
 the following protobuf message:
 ```protobuf
 
@@ -39,7 +39,7 @@ The following code can be used to evaluate a CEL expression on a Point message:
 ```rust
 use rscel::{CelContext, BindContext};
 
-// currently rscel required protobuf messages to be in a box 
+// currently rscel requires protobuf messages to be in a box
 let p = Box::new(protos::Point::new());
 p.x = 4;
 p.y = 5;

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["maturin>=1,<2"]
+build-backend = "maturin"
+
+[project]
+name = "rscel"
+version = "1.0.6"
+description = "Python bindings for the rscel package"
+readme = "../README.md"
+license = { file = "../LICENSE" }
+requires-python = ">=3.9"
+authors = [{ name = "rscel developers" }]
+

--- a/rscel/Cargo.toml
+++ b/rscel/Cargo.toml
@@ -30,3 +30,4 @@ duration-str = "0.13.0"
 protobuf = { version = "3.7.1", optional = true }
 chrono-tz = "0.10.1"
 num-traits = "0.2.19"
+once_cell = "1.19.0"

--- a/rscel/README.md
+++ b/rscel/README.md
@@ -1,0 +1,35 @@
+# rscel
+
+This crate provides the core implementation of the rscel CEL interpreter.
+
+## SQL compilation
+
+The `SqlCompiler` converts CEL abstract syntax trees (ASTs) into SQL fragments that can be executed in PostgreSQL.
+
+```rust
+use rscel::{Program, SqlCompiler, CelValue};
+
+let program = Program::from_source("1 + 2").unwrap();
+let ast = program.ast().unwrap();
+let frag = SqlCompiler::compile(ast).unwrap();
+
+assert_eq!(frag.sql, "($1 + $2)");
+assert_eq!(frag.params, vec![CelValue::from_int(1), CelValue::from_int(2)]);
+```
+
+This produces:
+
+```
+SQL: ($1 + $2)
+Params: [CelValue::from_int(1), CelValue::from_int(2)]
+```
+
+## Testing
+
+Run the full test suite before committing:
+
+```bash
+cargo +nightly-2025-08-08 test
+cargo +nightly-2025-08-08 test --no-default-features
+```
+

--- a/rscel/src/interp/interp.rs
+++ b/rscel/src/interp/interp.rs
@@ -405,7 +405,7 @@ impl<'a> Interpreter<'a> {
                 ByteCode::Call(n_args) => {
                     match stack.pop_noresolve()? {
                         CelStackValue::BoundCall { callable, value } => {
-                            let mut args = Vec::new();
+                            let mut args = Vec::with_capacity(*n_args as usize);
 
                             for _ in 0..*n_args {
                                 args.push(stack.pop()?.into_value()?)
@@ -417,12 +417,16 @@ impl<'a> Interpreter<'a> {
                                     stack.push_val(func(value, arg_values));
                                 }
                                 RsCallable::Macro(macro_) => {
-                                    stack.push_val(self.call_macro(&value, &args, macro_)?);
+                                    stack.push_val(self.call_macro(
+                                        &value,
+                                        args.as_slice(),
+                                        macro_,
+                                    )?);
                                 }
                             }
                         }
                         CelStackValue::Value(value) => {
-                            let mut args = Vec::new();
+                            let mut args = Vec::with_capacity(*n_args as usize);
 
                             for _ in 0..*n_args {
                                 args.push(stack.pop()?.into_value()?)
@@ -437,7 +441,7 @@ impl<'a> Interpreter<'a> {
                                     {
                                         stack.push_val(self.call_macro(
                                             &CelValue::from_null(),
-                                            &args,
+                                            args.as_slice(),
                                             macro_,
                                         )?);
                                     } else if let Some(CelValue::Type(type_name)) =
@@ -510,7 +514,7 @@ impl<'a> Interpreter<'a> {
     fn call_macro(
         &self,
         this: &CelValue,
-        args: &Vec<CelValue>,
+        args: &[CelValue],
         macro_: &RsCelMacro,
     ) -> Result<CelValue, CelError> {
         let mut v = Vec::new();

--- a/rscel/src/interp/interp.rs
+++ b/rscel/src/interp/interp.rs
@@ -14,9 +14,9 @@ struct InterpStack<'a, 'b> {
 }
 
 impl<'a, 'b> InterpStack<'a, 'b> {
-    fn new(ctx: &'b Interpreter) -> InterpStack<'a, 'b> {
+    fn new(ctx: &'b Interpreter, capacity: usize) -> InterpStack<'a, 'b> {
         InterpStack {
-            stack: Vec::new(),
+            stack: Vec::with_capacity(capacity),
             ctx,
         }
     }
@@ -142,7 +142,7 @@ impl<'a> Interpreter<'a> {
 
     pub fn run_raw(&self, prog: &CelByteCode, resolve: bool) -> CelResult<CelValue> {
         let mut pc: usize = 0;
-        let mut stack = InterpStack::new(self);
+        let mut stack = InterpStack::new(self, prog.len());
 
         let count = self.depth.inc();
 

--- a/rscel/src/lib.rs
+++ b/rscel/src/lib.rs
@@ -55,6 +55,7 @@ mod compiler;
 mod context;
 mod interp;
 mod program;
+mod sql;
 mod types;
 
 // Export some public interface
@@ -66,6 +67,7 @@ pub use compiler::{
 pub use context::{BindContext, CelContext, RsCelFunction, RsCelMacro};
 pub use interp::ByteCode;
 pub use program::{Program, ProgramDetails};
+pub use sql::{SqlCompiler, SqlFragment, ToSql};
 pub use types::{CelError, CelResult, CelValue, CelValueDyn};
 
 // Some re-exports to allow a consistent use of serde

--- a/rscel/src/lib.rs
+++ b/rscel/src/lib.rs
@@ -1,13 +1,13 @@
 #![feature(string_remove_matches)]
-//! RsCel is a CEL evaluator written in Rust. CEL is a google project that
+//! RsCel is a CEL evaluator written in Rust. CEL is a Google project that
 //! describes a turing-incomplete language that can be used to evaluate
-//! a user provdided expression. The language specification can be found
+//! a user provided expression. The language specification can be found
 //! [here](https://github.com/google/cel-spec/blob/master/doc/langdef.md).
 //!
-//! The design goals of this project were are as follows:
+//! The design goals of this project are as follows:
 //!   * Flexible enough to allow for a user to bend the spec if needed
-//!   * Sandbox'ed in such a way that only specific values can be bound
-//!   * Can be used as a wasm depenedency (or other ffi)
+//!   * Sandboxed in such a way that only specific values can be bound
+//!   * Can be used as a wasm dependency (or other ffi)
 //!
 //! The basic example of how to use:
 //! ```
@@ -22,7 +22,7 @@
 //! let res = ctx.exec("main", &exec_ctx).unwrap(); // CelValue::Int(6)
 //! assert_eq!(res, 6.into());
 //! ```
-//! As of 0.10.0 binding protobuf messages from the protobuf crate is now available! Given
+//! Binding protobuf messages from the protobuf crate is available! Given
 //! the following protobuf message:
 //! ```protobuf
 //!
@@ -37,7 +37,7 @@
 //! ```ignore
 //! use rscel::{CelContext, BindContext};
 //!
-//! // currently rscel required protobuf messages to be in a box
+//! // currently rscel requires protobuf messages to be in a box
 //! let p = Box::new(protos::Point::new());
 //! p.x = 4;
 //! p.y = 5;

--- a/rscel/src/lib.rs
+++ b/rscel/src/lib.rs
@@ -67,7 +67,7 @@ pub use compiler::{
 pub use context::{BindContext, CelContext, RsCelFunction, RsCelMacro};
 pub use interp::ByteCode;
 pub use program::{Program, ProgramDetails};
-pub use sql::{SqlCompiler, SqlFragment, ToSql};
+pub use sql::{SqlCompiler, SqlError, SqlFragment, ToSql};
 pub use types::{CelError, CelResult, CelValue, CelValueDyn};
 
 // Some re-exports to allow a consistent use of serde

--- a/rscel/src/sql/functions.rs
+++ b/rscel/src/sql/functions.rs
@@ -1,0 +1,83 @@
+use once_cell::sync::Lazy;
+use std::collections::HashMap;
+
+use super::{default_call, join_fragments, SqlFragment};
+
+pub type SqlFunc = Box<dyn Fn(Vec<SqlFragment>) -> SqlFragment + Send + Sync>;
+
+fn simple(name: &'static str) -> SqlFunc {
+    Box::new(move |args| default_call(name, args))
+}
+
+fn extract(part: &'static str) -> SqlFunc {
+    Box::new(move |args| {
+        let (parts, params) = join_fragments(args);
+        SqlFragment {
+            sql: format!("EXTRACT({} FROM {})", part, parts[0]),
+            params,
+        }
+    })
+}
+
+pub static FUNCTIONS: Lazy<HashMap<&'static str, SqlFunc>> = Lazy::new(|| {
+    let mut m: HashMap<&'static str, SqlFunc> = HashMap::new();
+
+    // Math
+    m.insert("abs", simple("ABS"));
+    m.insert("sqrt", simple("SQRT"));
+    m.insert("pow", simple("POWER"));
+    m.insert("log", simple("LOG"));
+    m.insert("ceil", simple("CEIL"));
+    m.insert("floor", simple("FLOOR"));
+    m.insert("round", simple("ROUND"));
+    m.insert("min", simple("LEAST"));
+    m.insert("max", simple("GREATEST"));
+
+    // String
+    m.insert("toLower", simple("LOWER"));
+    m.insert("toUpper", simple("UPPER"));
+    m.insert("trim", simple("TRIM"));
+    m.insert("trimStart", simple("LTRIM"));
+    m.insert("trimEnd", simple("RTRIM"));
+    m.insert(
+        "contains",
+        Box::new(|args| {
+            let (parts, params) = join_fragments(args);
+            SqlFragment {
+                sql: format!("({} LIKE '%' || {} || '%')", parts[0], parts[1]),
+                params,
+            }
+        }),
+    );
+    m.insert(
+        "startsWith",
+        Box::new(|args| {
+            let (parts, params) = join_fragments(args);
+            SqlFragment {
+                sql: format!("({} LIKE {} || '%')", parts[0], parts[1]),
+                params,
+            }
+        }),
+    );
+    m.insert(
+        "endsWith",
+        Box::new(|args| {
+            let (parts, params) = join_fragments(args);
+            SqlFragment {
+                sql: format!("({} LIKE '%' || {})", parts[0], parts[1]),
+                params,
+            }
+        }),
+    );
+
+    // Time
+    m.insert("getFullYear", extract("YEAR"));
+    m.insert("getMonth", extract("MONTH"));
+    m.insert("getDayOfMonth", extract("DAY"));
+    m.insert("getDayOfWeek", extract("DOW"));
+    m.insert("getHours", extract("HOUR"));
+    m.insert("getMinutes", extract("MINUTE"));
+    m.insert("getSeconds", extract("SECOND"));
+
+    m
+});

--- a/rscel/src/sql/mod.rs
+++ b/rscel/src/sql/mod.rs
@@ -13,6 +13,7 @@
 //! are assumed to contain the referenced structure at runtime.
 
 use regex::Regex;
+use std::fmt;
 
 mod functions;
 
@@ -33,12 +34,38 @@ pub struct SqlFragment {
     pub params: Vec<CelValue>,
 }
 
+/// Result type used by SQL compilation routines.
+pub type SqlResult<T> = Result<T, SqlError>;
+
+/// Errors that can occur during SQL compilation.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SqlError {
+    /// Feature is not supported by the SQL compiler.
+    UnsupportedFeature(String),
+    /// Type of an expression is invalid for the requested operation.
+    InvalidType(String),
+    /// An unexpected internal failure occurred.
+    Internal(String),
+}
+
+impl fmt::Display for SqlError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SqlError::UnsupportedFeature(s) => write!(f, "unsupported feature: {}", s),
+            SqlError::InvalidType(s) => write!(f, "invalid type: {}", s),
+            SqlError::Internal(s) => write!(f, "internal error: {}", s),
+        }
+    }
+}
+
+impl std::error::Error for SqlError {}
+
 /// Compiler that converts CEL AST nodes into SQL fragments.
 pub struct SqlCompiler;
 
 impl SqlCompiler {
     /// Compile a CEL expression AST into a [`SqlFragment`].
-    pub fn compile(ast: &AstNode<Expr>) -> SqlFragment {
+    pub fn compile(ast: &AstNode<Expr>) -> SqlResult<SqlFragment> {
         let compiler = SqlCompiler;
         ast.to_sql(&compiler)
     }
@@ -47,7 +74,7 @@ impl SqlCompiler {
 /// Trait for converting a type into a [`SqlFragment`].
 pub trait ToSql {
     /// Convert `self` into a [`SqlFragment`] using the provided compiler.
-    fn to_sql(&self, compiler: &SqlCompiler) -> SqlFragment;
+    fn to_sql(&self, compiler: &SqlCompiler) -> SqlResult<SqlFragment>;
 }
 
 /// Shift placeholder numbers in `sql` by `offset`.
@@ -95,51 +122,54 @@ pub(super) fn default_call(name: &str, args: Vec<SqlFragment>) -> SqlFragment {
 }
 
 impl SqlCompiler {
-    fn call_function(&self, name: &str, args: Vec<SqlFragment>) -> SqlFragment {
+    fn call_function(&self, name: &str, args: Vec<SqlFragment>) -> SqlResult<SqlFragment> {
         if let Some(func) = functions::FUNCTIONS.get(name) {
             func(args)
         } else {
-            default_call(name, args)
+            Err(SqlError::UnsupportedFeature(format!(
+                "function '{}' is not supported",
+                name
+            )))
         }
     }
 }
 
 impl<T: ToSql> ToSql for AstNode<T> {
-    fn to_sql(&self, compiler: &SqlCompiler) -> SqlFragment {
+    fn to_sql(&self, compiler: &SqlCompiler) -> SqlResult<SqlFragment> {
         self.node().to_sql(compiler)
     }
 }
 
 impl ToSql for Expr {
-    fn to_sql(&self, compiler: &SqlCompiler) -> SqlFragment {
+    fn to_sql(&self, compiler: &SqlCompiler) -> SqlResult<SqlFragment> {
         match self {
             Expr::Ternary {
                 condition,
                 true_clause,
                 false_clause,
             } => {
-                let cond = condition.to_sql(compiler);
-                let true_frag = true_clause.to_sql(compiler);
+                let cond = condition.to_sql(compiler)?;
+                let true_frag = true_clause.to_sql(compiler)?;
                 let offset_true = cond.params.len();
                 let true_sql = shift_placeholders(&true_frag.sql, offset_true);
                 let mut params = cond.params.clone();
                 params.extend(true_frag.params);
 
-                let false_frag = false_clause.to_sql(compiler);
+                let false_frag = false_clause.to_sql(compiler)?;
                 let offset_false = params.len();
                 let false_sql = shift_placeholders(&false_frag.sql, offset_false);
                 params.extend(false_frag.params);
 
-                SqlFragment {
+                Ok(SqlFragment {
                     sql: format!(
                         "(CASE WHEN {} THEN {} ELSE {} END)",
                         cond.sql, true_sql, false_sql
                     ),
                     params,
-                }
+                })
             }
             Expr::Match { condition, cases } => {
-                let cond = condition.to_sql(compiler);
+                let cond = condition.to_sql(compiler)?;
                 let mut sql = String::from("CASE");
                 let mut params = cond.params.clone();
 
@@ -149,10 +179,10 @@ impl ToSql for Expr {
                         &cond.sql,
                         compiler,
                         params.len(),
-                    );
+                    )?;
                     params.extend(pat_params.drain(..));
 
-                    let expr_frag = case_node.expr.to_sql(compiler);
+                    let expr_frag = case_node.expr.to_sql(compiler)?;
                     let expr_sql = shift_placeholders(&expr_frag.sql, params.len());
                     params.extend(expr_frag.params);
 
@@ -160,7 +190,7 @@ impl ToSql for Expr {
                 }
 
                 sql.push_str(" END");
-                SqlFragment { sql, params }
+                Ok(SqlFragment { sql, params })
             }
             Expr::Unary(or) => or.to_sql(compiler),
         }
@@ -173,13 +203,13 @@ impl MatchPattern {
         cond_sql: &str,
         compiler: &SqlCompiler,
         offset: usize,
-    ) -> (String, Vec<CelValue>) {
+    ) -> SqlResult<(String, Vec<CelValue>)> {
         match self {
             MatchPattern::Cmp { op, or } => {
-                let or_frag = or.to_sql(compiler);
+                let or_frag = or.to_sql(compiler)?;
                 let or_sql = shift_placeholders(&or_frag.sql, offset);
-                let op_sql = op.to_sql(compiler).sql;
-                (
+                let op_sql = op.to_sql(compiler)?.sql;
+                Ok((
                     format!(
                         "{} {} {}",
                         shift_placeholders(cond_sql, offset),
@@ -187,49 +217,49 @@ impl MatchPattern {
                         or_sql
                     ),
                     or_frag.params,
-                )
+                ))
             }
             MatchPattern::Type(t) => {
                 let type_str = t.node().to_pg_type();
-                (
+                Ok((
                     format!(
                         "pg_typeof({}) = '{}'",
                         shift_placeholders(cond_sql, offset),
                         type_str
                     ),
                     Vec::new(),
-                )
+                ))
             }
-            MatchPattern::Any(_) => ("TRUE".to_string(), Vec::new()),
+            MatchPattern::Any(_) => Ok(("TRUE".to_string(), Vec::new())),
         }
     }
 }
 
 impl ToSql for MatchPattern {
-    fn to_sql(&self, compiler: &SqlCompiler) -> SqlFragment {
-        let (sql, params) = self.to_sql_with_cond("$1", compiler, 0);
-        SqlFragment { sql, params }
+    fn to_sql(&self, compiler: &SqlCompiler) -> SqlResult<SqlFragment> {
+        let (sql, params) = self.to_sql_with_cond("$1", compiler, 0)?;
+        Ok(SqlFragment { sql, params })
     }
 }
 
 impl ToSql for MatchCase {
-    fn to_sql(&self, compiler: &SqlCompiler) -> SqlFragment {
+    fn to_sql(&self, compiler: &SqlCompiler) -> SqlResult<SqlFragment> {
         // Placeholder compilation; actual combination handled in Expr::Match
-        let (pattern_sql, params) = self.pattern.node().to_sql_with_cond("$1", compiler, 0);
-        let expr_frag = self.expr.to_sql(compiler);
-        SqlFragment {
+        let (pattern_sql, params) = self.pattern.node().to_sql_with_cond("$1", compiler, 0)?;
+        let expr_frag = self.expr.to_sql(compiler)?;
+        Ok(SqlFragment {
             sql: format!(
                 "WHEN {} THEN {}",
                 pattern_sql,
                 shift_placeholders(&expr_frag.sql, params.len())
             ),
             params: [params, expr_frag.params].concat(),
-        }
+        })
     }
 }
 
 impl ToSql for MatchCmpOp {
-    fn to_sql(&self, _compiler: &SqlCompiler) -> SqlFragment {
+    fn to_sql(&self, _compiler: &SqlCompiler) -> SqlResult<SqlFragment> {
         let sql = match self {
             MatchCmpOp::Eq => "=",
             MatchCmpOp::Neq => "!=",
@@ -238,10 +268,10 @@ impl ToSql for MatchCmpOp {
             MatchCmpOp::Lt => "<",
             MatchCmpOp::Le => "<=",
         };
-        SqlFragment {
+        Ok(SqlFragment {
             sql: sql.to_string(),
             params: Vec::new(),
-        }
+        })
     }
 }
 
@@ -264,30 +294,30 @@ impl MatchTypePattern {
 }
 
 impl ToSql for MatchTypePattern {
-    fn to_sql(&self, _compiler: &SqlCompiler) -> SqlFragment {
-        SqlFragment {
+    fn to_sql(&self, _compiler: &SqlCompiler) -> SqlResult<SqlFragment> {
+        Ok(SqlFragment {
             sql: format!("'{}'", self.to_pg_type()),
             params: Vec::new(),
-        }
+        })
     }
 }
 
 impl ToSql for MatchAnyPattern {
-    fn to_sql(&self, _compiler: &SqlCompiler) -> SqlFragment {
-        SqlFragment {
+    fn to_sql(&self, _compiler: &SqlCompiler) -> SqlResult<SqlFragment> {
+        Ok(SqlFragment {
             sql: "TRUE".to_string(),
             params: Vec::new(),
-        }
+        })
     }
 }
 
 impl ToSql for ConditionalOr {
-    fn to_sql(&self, compiler: &SqlCompiler) -> SqlFragment {
+    fn to_sql(&self, compiler: &SqlCompiler) -> SqlResult<SqlFragment> {
         match self {
             ConditionalOr::Binary { lhs, rhs } => {
-                let lhs_frag = lhs.to_sql(compiler);
-                let rhs_frag = rhs.to_sql(compiler);
-                merge_fragments(lhs_frag, rhs_frag, "OR")
+                let lhs_frag = lhs.to_sql(compiler)?;
+                let rhs_frag = rhs.to_sql(compiler)?;
+                Ok(merge_fragments(lhs_frag, rhs_frag, "OR"))
             }
             ConditionalOr::Unary(inner) => inner.to_sql(compiler),
         }
@@ -295,12 +325,12 @@ impl ToSql for ConditionalOr {
 }
 
 impl ToSql for ConditionalAnd {
-    fn to_sql(&self, compiler: &SqlCompiler) -> SqlFragment {
+    fn to_sql(&self, compiler: &SqlCompiler) -> SqlResult<SqlFragment> {
         match self {
             ConditionalAnd::Binary { lhs, rhs } => {
-                let lhs_frag = lhs.to_sql(compiler);
-                let rhs_frag = rhs.to_sql(compiler);
-                merge_fragments(lhs_frag, rhs_frag, "AND")
+                let lhs_frag = lhs.to_sql(compiler)?;
+                let rhs_frag = rhs.to_sql(compiler)?;
+                Ok(merge_fragments(lhs_frag, rhs_frag, "AND"))
             }
             ConditionalAnd::Unary(inner) => inner.to_sql(compiler),
         }
@@ -308,19 +338,24 @@ impl ToSql for ConditionalAnd {
 }
 
 impl ToSql for Relation {
-    fn to_sql(&self, compiler: &SqlCompiler) -> SqlFragment {
+    fn to_sql(&self, compiler: &SqlCompiler) -> SqlResult<SqlFragment> {
         match self {
             Relation::Binary { lhs, op, rhs } => {
-                let lhs_frag = lhs.to_sql(compiler);
-                let rhs_frag = rhs.to_sql(compiler);
+                let lhs_frag = lhs.to_sql(compiler)?;
+                let rhs_frag = rhs.to_sql(compiler)?;
                 let offset = lhs_frag.params.len();
                 let rhs_sql = shift_placeholders(&rhs_frag.sql, offset);
                 let mut params = lhs_frag.params;
                 params.extend(rhs_frag.params);
-                SqlFragment {
-                    sql: format!("({} {} {})", lhs_frag.sql, op.to_sql(compiler).sql, rhs_sql),
+                Ok(SqlFragment {
+                    sql: format!(
+                        "({} {} {})",
+                        lhs_frag.sql,
+                        op.to_sql(compiler)?.sql,
+                        rhs_sql
+                    ),
                     params,
-                }
+                })
             }
             Relation::Unary(inner) => inner.to_sql(compiler),
         }
@@ -328,7 +363,7 @@ impl ToSql for Relation {
 }
 
 impl ToSql for Relop {
-    fn to_sql(&self, _compiler: &SqlCompiler) -> SqlFragment {
+    fn to_sql(&self, _compiler: &SqlCompiler) -> SqlResult<SqlFragment> {
         let sql = match self {
             Relop::Le => "<=",
             Relop::Lt => "<",
@@ -338,20 +373,24 @@ impl ToSql for Relop {
             Relop::Ne => "!=",
             Relop::In => "IN",
         };
-        SqlFragment {
+        Ok(SqlFragment {
             sql: sql.to_string(),
             params: Vec::new(),
-        }
+        })
     }
 }
 
 impl ToSql for Addition {
-    fn to_sql(&self, compiler: &SqlCompiler) -> SqlFragment {
+    fn to_sql(&self, compiler: &SqlCompiler) -> SqlResult<SqlFragment> {
         match self {
             Addition::Binary { lhs, op, rhs } => {
-                let lhs_frag = lhs.to_sql(compiler);
-                let rhs_frag = rhs.to_sql(compiler);
-                merge_fragments(lhs_frag, rhs_frag, &op.to_sql(compiler).sql)
+                let lhs_frag = lhs.to_sql(compiler)?;
+                let rhs_frag = rhs.to_sql(compiler)?;
+                Ok(merge_fragments(
+                    lhs_frag,
+                    rhs_frag,
+                    &op.to_sql(compiler)?.sql,
+                ))
             }
             Addition::Unary(inner) => inner.to_sql(compiler),
         }
@@ -359,25 +398,29 @@ impl ToSql for Addition {
 }
 
 impl ToSql for AddOp {
-    fn to_sql(&self, _compiler: &SqlCompiler) -> SqlFragment {
+    fn to_sql(&self, _compiler: &SqlCompiler) -> SqlResult<SqlFragment> {
         let sql = match self {
             AddOp::Add => "+",
             AddOp::Sub => "-",
         };
-        SqlFragment {
+        Ok(SqlFragment {
             sql: sql.to_string(),
             params: Vec::new(),
-        }
+        })
     }
 }
 
 impl ToSql for Multiplication {
-    fn to_sql(&self, compiler: &SqlCompiler) -> SqlFragment {
+    fn to_sql(&self, compiler: &SqlCompiler) -> SqlResult<SqlFragment> {
         match self {
             Multiplication::Binary { lhs, op, rhs } => {
-                let lhs_frag = lhs.to_sql(compiler);
-                let rhs_frag = rhs.to_sql(compiler);
-                merge_fragments(lhs_frag, rhs_frag, &op.to_sql(compiler).sql)
+                let lhs_frag = lhs.to_sql(compiler)?;
+                let rhs_frag = rhs.to_sql(compiler)?;
+                Ok(merge_fragments(
+                    lhs_frag,
+                    rhs_frag,
+                    &op.to_sql(compiler)?.sql,
+                ))
             }
             Multiplication::Unary(inner) => inner.to_sql(compiler),
         }
@@ -385,16 +428,16 @@ impl ToSql for Multiplication {
 }
 
 impl ToSql for MultOp {
-    fn to_sql(&self, _compiler: &SqlCompiler) -> SqlFragment {
+    fn to_sql(&self, _compiler: &SqlCompiler) -> SqlResult<SqlFragment> {
         let sql = match self {
             MultOp::Mult => "*",
             MultOp::Div => "/",
             MultOp::Mod => "%",
         };
-        SqlFragment {
+        Ok(SqlFragment {
             sql: sql.to_string(),
             params: Vec::new(),
-        }
+        })
     }
 }
 
@@ -408,11 +451,11 @@ impl NotList {
 }
 
 impl ToSql for NotList {
-    fn to_sql(&self, _compiler: &SqlCompiler) -> SqlFragment {
-        SqlFragment {
+    fn to_sql(&self, _compiler: &SqlCompiler) -> SqlResult<SqlFragment> {
+        Ok(SqlFragment {
             sql: String::new(),
             params: Vec::new(),
-        }
+        })
     }
 }
 
@@ -426,39 +469,45 @@ impl NegList {
 }
 
 impl ToSql for NegList {
-    fn to_sql(&self, _compiler: &SqlCompiler) -> SqlFragment {
-        SqlFragment {
+    fn to_sql(&self, _compiler: &SqlCompiler) -> SqlResult<SqlFragment> {
+        Ok(SqlFragment {
             sql: String::new(),
             params: Vec::new(),
-        }
+        })
     }
 }
 
 impl ToSql for Unary {
-    fn to_sql(&self, compiler: &SqlCompiler) -> SqlFragment {
+    fn to_sql(&self, compiler: &SqlCompiler) -> SqlResult<SqlFragment> {
         match self {
             Unary::Member(m) => m.to_sql(compiler),
             Unary::NotMember { nots, member } => {
-                let mut frag = member.to_sql(compiler);
+                let mut frag = member.to_sql(compiler)?;
                 for _ in 0..nots.node().count() {
                     frag.sql = format!("(NOT {})", frag.sql);
                 }
-                frag
+                Ok(frag)
             }
             Unary::NegMember { negs, member } => {
-                let mut frag = member.to_sql(compiler);
+                let mut frag = member.to_sql(compiler)?;
                 for _ in 0..negs.node().count() {
                     frag.sql = format!("(-{})", frag.sql);
                 }
-                frag
+                Ok(frag)
             }
         }
     }
 }
 
 impl ToSql for Member {
-    fn to_sql(&self, compiler: &SqlCompiler) -> SqlFragment {
-        let mut frag = self.primary.to_sql(compiler);
+    fn to_sql(&self, compiler: &SqlCompiler) -> SqlResult<SqlFragment> {
+        if matches!(self.primary.node(), Primary::Literal(_)) && !self.member.is_empty() {
+            return Err(SqlError::InvalidType(
+                "cannot access property on literal".to_string(),
+            ));
+        }
+
+        let mut frag = self.primary.to_sql(compiler)?;
         let mut chain_sql = String::new();
         let mut chain_params: Vec<CelValue> = Vec::new();
 
@@ -480,18 +529,18 @@ impl ToSql for Member {
                             iter.next();
                             let mut args: Vec<SqlFragment> = vec![frag];
                             for expr in call.node().exprs.iter().rev() {
-                                args.push(expr.to_sql(compiler));
+                                args.push(expr.to_sql(compiler)?);
                             }
-                            frag = compiler.call_function(&ident.node().0, args);
+                            frag = compiler.call_function(&ident.node().0, args)?;
                         } else {
-                            let current = m.to_sql(compiler);
+                            let current = m.to_sql(compiler)?;
                             let offset = frag.params.len() + chain_params.len();
                             let sql = shift_placeholders(&current.sql, offset);
                             chain_sql.push_str(&sql);
                             chain_params.extend(current.params);
                         }
                     } else {
-                        let current = m.to_sql(compiler);
+                        let current = m.to_sql(compiler)?;
                         let offset = frag.params.len() + chain_params.len();
                         let sql = shift_placeholders(&current.sql, offset);
                         chain_sql.push_str(&sql);
@@ -509,12 +558,12 @@ impl ToSql for Member {
                     }
                     let mut args: Vec<SqlFragment> = Vec::new();
                     for expr in call.node().exprs.iter().rev() {
-                        args.push(expr.to_sql(compiler));
+                        args.push(expr.to_sql(compiler)?);
                     }
-                    frag = compiler.call_function(&frag.sql, args);
+                    frag = compiler.call_function(&frag.sql, args)?;
                 }
                 _ => {
-                    let current = m.to_sql(compiler);
+                    let current = m.to_sql(compiler)?;
                     let offset = frag.params.len() + chain_params.len();
                     let sql = shift_placeholders(&current.sql, offset);
                     chain_sql.push_str(&sql);
@@ -531,69 +580,69 @@ impl ToSql for Member {
             frag.params.extend(chain_params);
         }
 
-        frag
+        Ok(frag)
     }
 }
 
 impl ToSql for MemberPrime {
-    fn to_sql(&self, compiler: &SqlCompiler) -> SqlFragment {
+    fn to_sql(&self, compiler: &SqlCompiler) -> SqlResult<SqlFragment> {
         match self {
-            MemberPrime::MemberAccess { ident } => SqlFragment {
+            MemberPrime::MemberAccess { ident } => Ok(SqlFragment {
                 sql: format!(" -> '{}'", ident.node().0),
                 params: Vec::new(),
-            },
+            }),
             MemberPrime::Call { call } => {
-                let frag = call.to_sql(compiler);
-                SqlFragment {
+                let frag = call.to_sql(compiler)?;
+                Ok(SqlFragment {
                     sql: frag.sql,
                     params: frag.params,
-                }
+                })
             }
             MemberPrime::ArrayAccess { access } => {
-                let frag = access.to_sql(compiler);
-                SqlFragment {
+                let frag = access.to_sql(compiler)?;
+                Ok(SqlFragment {
                     sql: format!(" -> ({})", frag.sql),
                     params: frag.params,
-                }
+                })
             }
-            MemberPrime::Empty => SqlFragment {
+            MemberPrime::Empty => Ok(SqlFragment {
                 sql: String::new(),
                 params: Vec::new(),
-            },
+            }),
         }
     }
 }
 
 impl ToSql for Ident {
-    fn to_sql(&self, _compiler: &SqlCompiler) -> SqlFragment {
-        SqlFragment {
+    fn to_sql(&self, _compiler: &SqlCompiler) -> SqlResult<SqlFragment> {
+        Ok(SqlFragment {
             sql: self.0.clone(),
             params: Vec::new(),
-        }
+        })
     }
 }
 
 impl ToSql for Primary {
-    fn to_sql(&self, compiler: &SqlCompiler) -> SqlFragment {
+    fn to_sql(&self, compiler: &SqlCompiler) -> SqlResult<SqlFragment> {
         match self {
-            Primary::Type => SqlFragment {
+            Primary::Type => Ok(SqlFragment {
                 sql: "type".to_string(),
                 params: Vec::new(),
-            },
+            }),
             Primary::Ident(id) => id.to_sql(compiler),
             Primary::Parens(expr) => {
-                let frag = expr.to_sql(compiler);
-                SqlFragment {
+                let frag = expr.to_sql(compiler)?;
+                Ok(SqlFragment {
                     sql: format!("({})", frag.sql),
                     params: frag.params,
-                }
+                })
             }
             Primary::ListConstruction(list) => {
-                let frag = list.to_sql(compiler);
-                SqlFragment {
+                let frag = list.to_sql(compiler)?;
+                Ok(SqlFragment {
                     sql: format!("ARRAY[{}]", frag.sql),
                     params: frag.params,
-                }
+                })
             }
             Primary::ObjectInit(obj) => obj.to_sql(compiler),
             Primary::Literal(lit) => lit.to_sql(compiler),
@@ -602,44 +651,44 @@ impl ToSql for Primary {
 }
 
 impl ToSql for ExprList {
-    fn to_sql(&self, compiler: &SqlCompiler) -> SqlFragment {
+    fn to_sql(&self, compiler: &SqlCompiler) -> SqlResult<SqlFragment> {
         let mut sql_parts = Vec::new();
         let mut params = Vec::new();
         for expr in &self.exprs {
-            let frag = expr.to_sql(compiler);
+            let frag = expr.to_sql(compiler)?;
             let sql = shift_placeholders(&frag.sql, params.len());
             params.extend(frag.params);
             sql_parts.push(sql);
         }
-        SqlFragment {
+        Ok(SqlFragment {
             sql: sql_parts.join(", "),
             params,
-        }
+        })
     }
 }
 
 impl ToSql for ObjInit {
-    fn to_sql(&self, compiler: &SqlCompiler) -> SqlFragment {
-        let key_frag = self.key.to_sql(compiler);
-        let val_frag = self.value.to_sql(compiler);
+    fn to_sql(&self, compiler: &SqlCompiler) -> SqlResult<SqlFragment> {
+        let key_frag = self.key.to_sql(compiler)?;
+        let val_frag = self.value.to_sql(compiler)?;
         let offset = key_frag.params.len();
-        SqlFragment {
+        Ok(SqlFragment {
             sql: format!(
                 "{}, {}",
                 key_frag.sql,
                 shift_placeholders(&val_frag.sql, offset)
             ),
             params: [key_frag.params, val_frag.params].concat(),
-        }
+        })
     }
 }
 
 impl ToSql for ObjInits {
-    fn to_sql(&self, compiler: &SqlCompiler) -> SqlFragment {
+    fn to_sql(&self, compiler: &SqlCompiler) -> SqlResult<SqlFragment> {
         let mut sql = String::new();
         let mut params = Vec::new();
         for (i, init) in self.inits.iter().enumerate() {
-            let frag = init.to_sql(compiler);
+            let frag = init.to_sql(compiler)?;
             let sql_shift = shift_placeholders(&frag.sql, params.len());
             params.extend(frag.params);
             if i > 0 {
@@ -647,25 +696,25 @@ impl ToSql for ObjInits {
             }
             sql.push_str(&sql_shift);
         }
-        SqlFragment {
+        Ok(SqlFragment {
             sql: format!("jsonb_build_object({})", sql),
             params,
-        }
+        })
     }
 }
 
 impl ToSql for NoAst {
-    fn to_sql(&self, _compiler: &SqlCompiler) -> SqlFragment {
-        SqlFragment {
+    fn to_sql(&self, _compiler: &SqlCompiler) -> SqlResult<SqlFragment> {
+        Ok(SqlFragment {
             sql: String::new(),
             params: Vec::new(),
-        }
+        })
     }
 }
 
 impl ToSql for LiteralsAndKeywords {
-    fn to_sql(&self, _compiler: &SqlCompiler) -> SqlFragment {
-        match self {
+    fn to_sql(&self, _compiler: &SqlCompiler) -> SqlResult<SqlFragment> {
+        let frag = match self {
             LiteralsAndKeywords::NullLit => SqlFragment {
                 sql: "$1".to_string(),
                 params: vec![CelValue::from_null()],
@@ -711,6 +760,7 @@ impl ToSql for LiteralsAndKeywords {
                 sql: String::new(),
                 params: Vec::new(),
             },
-        }
+        };
+        Ok(frag)
     }
 }

--- a/rscel/src/sql/mod.rs
+++ b/rscel/src/sql/mod.rs
@@ -4,13 +4,16 @@
 //! expressions into SQL fragments consisting of SQL text and a list
 //! of bound parameters.
 //!
-//! # JSON assumptions
+//! # PostgreSQL and JSON assumptions
 //!
-//! The generated SQL targets PostgreSQL `jsonb` values. Field and array
-//! accesses are translated into `jsonb` operator chains (`->` and `->>`),
-//! with the final segment in a chain extracted using `->>` to produce a
-//! text value. Array indices use `jsonb` subscripting. The JSON documents
-//! are assumed to contain the referenced structure at runtime.
+//! Generated SQL is intended for PostgreSQL. CEL variables are assumed
+//! to map to `jsonb` columns, and field or array accesses are translated
+//! into chains of the `->` and `->>` operators with the final segment
+//! extracted using `->>` to produce a text value. Array indices use
+//! `jsonb` subscripting. Literal values become numbered placeholders
+//! (`$1`, `$2`, ...), which should be bound in prepared statements. The
+//! referenced JSON structure is expected to exist at runtime; missing
+//! fields result in `NULL` values.
 
 use regex::Regex;
 use std::fmt;

--- a/rscel/src/sql/mod.rs
+++ b/rscel/src/sql/mod.rs
@@ -4,7 +4,15 @@
 //! expressions into SQL fragments consisting of SQL text and a list
 //! of bound parameters.
 
-use crate::{AstNode, CelValue, Expr};
+use regex::Regex;
+
+use crate::compiler::tokens::FStringSegment;
+use crate::{
+    AddOp, Addition, AstNode, CelValue, ConditionalAnd, ConditionalOr, Expr, ExprList, Ident,
+    LiteralsAndKeywords, MatchAnyPattern, MatchCase, MatchCmpOp, MatchPattern, MatchTypePattern,
+    Member, MemberPrime, MultOp, Multiplication, NegList, NoAst, NotList, ObjInit, ObjInits,
+    Primary, Relation, Relop, Unary,
+};
 
 /// SQL text and its associated parameter values.
 #[derive(Debug, Clone, PartialEq)]
@@ -32,11 +40,572 @@ pub trait ToSql {
     fn to_sql(&self, compiler: &SqlCompiler) -> SqlFragment;
 }
 
-impl ToSql for AstNode<Expr> {
+/// Shift placeholder numbers in `sql` by `offset`.
+fn shift_placeholders(sql: &str, offset: usize) -> String {
+    if offset == 0 {
+        return sql.to_string();
+    }
+    let re = Regex::new(r"\$(\d+)").unwrap();
+    re.replace_all(sql, |caps: &regex::Captures| {
+        let n: usize = caps[1].parse().unwrap();
+        format!("${}", n + offset)
+    })
+    .into_owned()
+}
+
+fn merge_fragments(lhs: SqlFragment, rhs: SqlFragment, join: &str) -> SqlFragment {
+    let offset = lhs.params.len();
+    let rhs_sql = shift_placeholders(&rhs.sql, offset);
+    let mut params = lhs.params;
+    params.extend(rhs.params);
+    SqlFragment {
+        sql: format!("({} {} {})", lhs.sql, join, rhs_sql),
+        params,
+    }
+}
+
+impl<T: ToSql> ToSql for AstNode<T> {
+    fn to_sql(&self, compiler: &SqlCompiler) -> SqlFragment {
+        self.node().to_sql(compiler)
+    }
+}
+
+impl ToSql for Expr {
+    fn to_sql(&self, compiler: &SqlCompiler) -> SqlFragment {
+        match self {
+            Expr::Ternary {
+                condition,
+                true_clause,
+                false_clause,
+            } => {
+                let cond = condition.to_sql(compiler);
+                let true_frag = true_clause.to_sql(compiler);
+                let offset_true = cond.params.len();
+                let true_sql = shift_placeholders(&true_frag.sql, offset_true);
+                let mut params = cond.params.clone();
+                params.extend(true_frag.params);
+
+                let false_frag = false_clause.to_sql(compiler);
+                let offset_false = params.len();
+                let false_sql = shift_placeholders(&false_frag.sql, offset_false);
+                params.extend(false_frag.params);
+
+                SqlFragment {
+                    sql: format!(
+                        "(CASE WHEN {} THEN {} ELSE {} END)",
+                        cond.sql, true_sql, false_sql
+                    ),
+                    params,
+                }
+            }
+            Expr::Match { condition, cases } => {
+                let cond = condition.to_sql(compiler);
+                let mut sql = String::from("CASE");
+                let mut params = cond.params.clone();
+
+                for case in cases {
+                    let case_node = case.node();
+                    let (pattern_sql, mut pat_params) = case_node.pattern.node().to_sql_with_cond(
+                        &cond.sql,
+                        compiler,
+                        params.len(),
+                    );
+                    params.extend(pat_params.drain(..));
+
+                    let expr_frag = case_node.expr.to_sql(compiler);
+                    let expr_sql = shift_placeholders(&expr_frag.sql, params.len());
+                    params.extend(expr_frag.params);
+
+                    sql.push_str(&format!(" WHEN {} THEN {}", pattern_sql, expr_sql));
+                }
+
+                sql.push_str(" END");
+                SqlFragment { sql, params }
+            }
+            Expr::Unary(or) => or.to_sql(compiler),
+        }
+    }
+}
+
+impl MatchPattern {
+    fn to_sql_with_cond(
+        &self,
+        cond_sql: &str,
+        compiler: &SqlCompiler,
+        offset: usize,
+    ) -> (String, Vec<CelValue>) {
+        match self {
+            MatchPattern::Cmp { op, or } => {
+                let or_frag = or.to_sql(compiler);
+                let or_sql = shift_placeholders(&or_frag.sql, offset);
+                let op_sql = op.to_sql(compiler).sql;
+                (
+                    format!(
+                        "{} {} {}",
+                        shift_placeholders(cond_sql, offset),
+                        op_sql,
+                        or_sql
+                    ),
+                    or_frag.params,
+                )
+            }
+            MatchPattern::Type(t) => {
+                let type_str = t.node().to_pg_type();
+                (
+                    format!(
+                        "pg_typeof({}) = '{}'",
+                        shift_placeholders(cond_sql, offset),
+                        type_str
+                    ),
+                    Vec::new(),
+                )
+            }
+            MatchPattern::Any(_) => ("TRUE".to_string(), Vec::new()),
+        }
+    }
+}
+
+impl ToSql for MatchPattern {
+    fn to_sql(&self, compiler: &SqlCompiler) -> SqlFragment {
+        let (sql, params) = self.to_sql_with_cond("$1", compiler, 0);
+        SqlFragment { sql, params }
+    }
+}
+
+impl ToSql for MatchCase {
+    fn to_sql(&self, compiler: &SqlCompiler) -> SqlFragment {
+        // Placeholder compilation; actual combination handled in Expr::Match
+        let (pattern_sql, params) = self.pattern.node().to_sql_with_cond("$1", compiler, 0);
+        let expr_frag = self.expr.to_sql(compiler);
+        SqlFragment {
+            sql: format!(
+                "WHEN {} THEN {}",
+                pattern_sql,
+                shift_placeholders(&expr_frag.sql, params.len())
+            ),
+            params: [params, expr_frag.params].concat(),
+        }
+    }
+}
+
+impl ToSql for MatchCmpOp {
+    fn to_sql(&self, _compiler: &SqlCompiler) -> SqlFragment {
+        let sql = match self {
+            MatchCmpOp::Eq => "=",
+            MatchCmpOp::Neq => "!=",
+            MatchCmpOp::Gt => ">",
+            MatchCmpOp::Ge => ">=",
+            MatchCmpOp::Lt => "<",
+            MatchCmpOp::Le => "<=",
+        };
+        SqlFragment {
+            sql: sql.to_string(),
+            params: Vec::new(),
+        }
+    }
+}
+
+impl MatchTypePattern {
+    fn to_pg_type(&self) -> &'static str {
+        match self {
+            MatchTypePattern::Int => "int8",
+            MatchTypePattern::Uint => "int8",
+            MatchTypePattern::Float => "float8",
+            MatchTypePattern::String => "text",
+            MatchTypePattern::Bool => "bool",
+            MatchTypePattern::Bytes => "bytea",
+            MatchTypePattern::List => "jsonb",
+            MatchTypePattern::Object => "jsonb",
+            MatchTypePattern::Null => "null",
+            MatchTypePattern::Timestamp => "timestamptz",
+            MatchTypePattern::Duration => "interval",
+        }
+    }
+}
+
+impl ToSql for MatchTypePattern {
+    fn to_sql(&self, _compiler: &SqlCompiler) -> SqlFragment {
+        SqlFragment {
+            sql: format!("'{}'", self.to_pg_type()),
+            params: Vec::new(),
+        }
+    }
+}
+
+impl ToSql for MatchAnyPattern {
+    fn to_sql(&self, _compiler: &SqlCompiler) -> SqlFragment {
+        SqlFragment {
+            sql: "TRUE".to_string(),
+            params: Vec::new(),
+        }
+    }
+}
+
+impl ToSql for ConditionalOr {
+    fn to_sql(&self, compiler: &SqlCompiler) -> SqlFragment {
+        match self {
+            ConditionalOr::Binary { lhs, rhs } => {
+                let lhs_frag = lhs.to_sql(compiler);
+                let rhs_frag = rhs.to_sql(compiler);
+                merge_fragments(lhs_frag, rhs_frag, "OR")
+            }
+            ConditionalOr::Unary(inner) => inner.to_sql(compiler),
+        }
+    }
+}
+
+impl ToSql for ConditionalAnd {
+    fn to_sql(&self, compiler: &SqlCompiler) -> SqlFragment {
+        match self {
+            ConditionalAnd::Binary { lhs, rhs } => {
+                let lhs_frag = lhs.to_sql(compiler);
+                let rhs_frag = rhs.to_sql(compiler);
+                merge_fragments(lhs_frag, rhs_frag, "AND")
+            }
+            ConditionalAnd::Unary(inner) => inner.to_sql(compiler),
+        }
+    }
+}
+
+impl ToSql for Relation {
+    fn to_sql(&self, compiler: &SqlCompiler) -> SqlFragment {
+        match self {
+            Relation::Binary { lhs, op, rhs } => {
+                let lhs_frag = lhs.to_sql(compiler);
+                let rhs_frag = rhs.to_sql(compiler);
+                let offset = lhs_frag.params.len();
+                let rhs_sql = shift_placeholders(&rhs_frag.sql, offset);
+                let mut params = lhs_frag.params;
+                params.extend(rhs_frag.params);
+                SqlFragment {
+                    sql: format!("({} {} {})", lhs_frag.sql, op.to_sql(compiler).sql, rhs_sql),
+                    params,
+                }
+            }
+            Relation::Unary(inner) => inner.to_sql(compiler),
+        }
+    }
+}
+
+impl ToSql for Relop {
+    fn to_sql(&self, _compiler: &SqlCompiler) -> SqlFragment {
+        let sql = match self {
+            Relop::Le => "<=",
+            Relop::Lt => "<",
+            Relop::Ge => ">=",
+            Relop::Gt => ">",
+            Relop::Eq => "=",
+            Relop::Ne => "!=",
+            Relop::In => "IN",
+        };
+        SqlFragment {
+            sql: sql.to_string(),
+            params: Vec::new(),
+        }
+    }
+}
+
+impl ToSql for Addition {
+    fn to_sql(&self, compiler: &SqlCompiler) -> SqlFragment {
+        match self {
+            Addition::Binary { lhs, op, rhs } => {
+                let lhs_frag = lhs.to_sql(compiler);
+                let rhs_frag = rhs.to_sql(compiler);
+                merge_fragments(lhs_frag, rhs_frag, &op.to_sql(compiler).sql)
+            }
+            Addition::Unary(inner) => inner.to_sql(compiler),
+        }
+    }
+}
+
+impl ToSql for AddOp {
+    fn to_sql(&self, _compiler: &SqlCompiler) -> SqlFragment {
+        let sql = match self {
+            AddOp::Add => "+",
+            AddOp::Sub => "-",
+        };
+        SqlFragment {
+            sql: sql.to_string(),
+            params: Vec::new(),
+        }
+    }
+}
+
+impl ToSql for Multiplication {
+    fn to_sql(&self, compiler: &SqlCompiler) -> SqlFragment {
+        match self {
+            Multiplication::Binary { lhs, op, rhs } => {
+                let lhs_frag = lhs.to_sql(compiler);
+                let rhs_frag = rhs.to_sql(compiler);
+                merge_fragments(lhs_frag, rhs_frag, &op.to_sql(compiler).sql)
+            }
+            Multiplication::Unary(inner) => inner.to_sql(compiler),
+        }
+    }
+}
+
+impl ToSql for MultOp {
+    fn to_sql(&self, _compiler: &SqlCompiler) -> SqlFragment {
+        let sql = match self {
+            MultOp::Mult => "*",
+            MultOp::Div => "/",
+            MultOp::Mod => "%",
+        };
+        SqlFragment {
+            sql: sql.to_string(),
+            params: Vec::new(),
+        }
+    }
+}
+
+impl NotList {
+    fn count(&self) -> usize {
+        match self {
+            NotList::List { tail } => 1 + tail.node().count(),
+            NotList::EmptyList => 0,
+        }
+    }
+}
+
+impl ToSql for NotList {
     fn to_sql(&self, _compiler: &SqlCompiler) -> SqlFragment {
         SqlFragment {
             sql: String::new(),
             params: Vec::new(),
+        }
+    }
+}
+
+impl NegList {
+    fn count(&self) -> usize {
+        match self {
+            NegList::List { tail } => 1 + tail.node().count(),
+            NegList::EmptyList => 0,
+        }
+    }
+}
+
+impl ToSql for NegList {
+    fn to_sql(&self, _compiler: &SqlCompiler) -> SqlFragment {
+        SqlFragment {
+            sql: String::new(),
+            params: Vec::new(),
+        }
+    }
+}
+
+impl ToSql for Unary {
+    fn to_sql(&self, compiler: &SqlCompiler) -> SqlFragment {
+        match self {
+            Unary::Member(m) => m.to_sql(compiler),
+            Unary::NotMember { nots, member } => {
+                let mut frag = member.to_sql(compiler);
+                for _ in 0..nots.node().count() {
+                    frag.sql = format!("(NOT {})", frag.sql);
+                }
+                frag
+            }
+            Unary::NegMember { negs, member } => {
+                let mut frag = member.to_sql(compiler);
+                for _ in 0..negs.node().count() {
+                    frag.sql = format!("(-{})", frag.sql);
+                }
+                frag
+            }
+        }
+    }
+}
+
+impl ToSql for Member {
+    fn to_sql(&self, compiler: &SqlCompiler) -> SqlFragment {
+        let mut frag = self.primary.to_sql(compiler);
+        for m in &self.member {
+            let current = m.to_sql(compiler);
+            let offset = frag.params.len();
+            let sql = shift_placeholders(&current.sql, offset);
+            frag.sql = format!("{}{}", frag.sql, sql);
+            frag.params.extend(current.params);
+        }
+        frag
+    }
+}
+
+impl ToSql for MemberPrime {
+    fn to_sql(&self, compiler: &SqlCompiler) -> SqlFragment {
+        match self {
+            MemberPrime::MemberAccess { ident } => SqlFragment {
+                sql: format!(".{}", ident.node().0.clone()),
+                params: Vec::new(),
+            },
+            MemberPrime::Call { call } => {
+                let frag = call.to_sql(compiler);
+                SqlFragment {
+                    sql: format!("({})", frag.sql),
+                    params: frag.params,
+                }
+            }
+            MemberPrime::ArrayAccess { access } => {
+                let frag = access.to_sql(compiler);
+                SqlFragment {
+                    sql: format!("[{}]", frag.sql),
+                    params: frag.params,
+                }
+            }
+            MemberPrime::Empty => SqlFragment {
+                sql: String::new(),
+                params: Vec::new(),
+            },
+        }
+    }
+}
+
+impl ToSql for Ident {
+    fn to_sql(&self, _compiler: &SqlCompiler) -> SqlFragment {
+        SqlFragment {
+            sql: self.0.clone(),
+            params: Vec::new(),
+        }
+    }
+}
+
+impl ToSql for Primary {
+    fn to_sql(&self, compiler: &SqlCompiler) -> SqlFragment {
+        match self {
+            Primary::Type => SqlFragment {
+                sql: "type".to_string(),
+                params: Vec::new(),
+            },
+            Primary::Ident(id) => id.to_sql(compiler),
+            Primary::Parens(expr) => {
+                let frag = expr.to_sql(compiler);
+                SqlFragment {
+                    sql: format!("({})", frag.sql),
+                    params: frag.params,
+                }
+            }
+            Primary::ListConstruction(list) => {
+                let frag = list.to_sql(compiler);
+                SqlFragment {
+                    sql: format!("ARRAY[{}]", frag.sql),
+                    params: frag.params,
+                }
+            }
+            Primary::ObjectInit(obj) => obj.to_sql(compiler),
+            Primary::Literal(lit) => lit.to_sql(compiler),
+        }
+    }
+}
+
+impl ToSql for ExprList {
+    fn to_sql(&self, compiler: &SqlCompiler) -> SqlFragment {
+        let mut sql_parts = Vec::new();
+        let mut params = Vec::new();
+        for expr in &self.exprs {
+            let frag = expr.to_sql(compiler);
+            let sql = shift_placeholders(&frag.sql, params.len());
+            params.extend(frag.params);
+            sql_parts.push(sql);
+        }
+        SqlFragment {
+            sql: sql_parts.join(", "),
+            params,
+        }
+    }
+}
+
+impl ToSql for ObjInit {
+    fn to_sql(&self, compiler: &SqlCompiler) -> SqlFragment {
+        let key_frag = self.key.to_sql(compiler);
+        let val_frag = self.value.to_sql(compiler);
+        let offset = key_frag.params.len();
+        SqlFragment {
+            sql: format!(
+                "{}, {}",
+                key_frag.sql,
+                shift_placeholders(&val_frag.sql, offset)
+            ),
+            params: [key_frag.params, val_frag.params].concat(),
+        }
+    }
+}
+
+impl ToSql for ObjInits {
+    fn to_sql(&self, compiler: &SqlCompiler) -> SqlFragment {
+        let mut sql = String::new();
+        let mut params = Vec::new();
+        for (i, init) in self.inits.iter().enumerate() {
+            let frag = init.to_sql(compiler);
+            let sql_shift = shift_placeholders(&frag.sql, params.len());
+            params.extend(frag.params);
+            if i > 0 {
+                sql.push_str(", ");
+            }
+            sql.push_str(&sql_shift);
+        }
+        SqlFragment {
+            sql: format!("jsonb_build_object({})", sql),
+            params,
+        }
+    }
+}
+
+impl ToSql for NoAst {
+    fn to_sql(&self, _compiler: &SqlCompiler) -> SqlFragment {
+        SqlFragment {
+            sql: String::new(),
+            params: Vec::new(),
+        }
+    }
+}
+
+impl ToSql for LiteralsAndKeywords {
+    fn to_sql(&self, _compiler: &SqlCompiler) -> SqlFragment {
+        match self {
+            LiteralsAndKeywords::NullLit => SqlFragment {
+                sql: "$1".to_string(),
+                params: vec![CelValue::from_null()],
+            },
+            LiteralsAndKeywords::IntegerLit(i) => SqlFragment {
+                sql: "$1".to_string(),
+                params: vec![CelValue::from_int(*i)],
+            },
+            LiteralsAndKeywords::UnsignedLit(u) => SqlFragment {
+                sql: "$1".to_string(),
+                params: vec![CelValue::from_uint(*u)],
+            },
+            LiteralsAndKeywords::FloatingLit(f) => SqlFragment {
+                sql: "$1".to_string(),
+                params: vec![CelValue::from_float(*f)],
+            },
+            LiteralsAndKeywords::FStringList(segs) => {
+                let mut s = String::new();
+                for seg in segs {
+                    match seg {
+                        FStringSegment::Lit(l) => s.push_str(l),
+                        FStringSegment::Expr(e) => s.push_str(e),
+                    }
+                }
+                SqlFragment {
+                    sql: "$1".to_string(),
+                    params: vec![CelValue::from_string(s)],
+                }
+            }
+            LiteralsAndKeywords::StringLit(s) => SqlFragment {
+                sql: "$1".to_string(),
+                params: vec![CelValue::from_string(s.clone())],
+            },
+            LiteralsAndKeywords::ByteStringLit(b) => SqlFragment {
+                sql: "$1".to_string(),
+                params: vec![CelValue::from_bytes(b.clone())],
+            },
+            LiteralsAndKeywords::BooleanLit(b) => SqlFragment {
+                sql: "$1".to_string(),
+                params: vec![CelValue::from_bool(*b)],
+            },
+            _ => SqlFragment {
+                sql: String::new(),
+                params: Vec::new(),
+            },
         }
     }
 }

--- a/rscel/src/sql/mod.rs
+++ b/rscel/src/sql/mod.rs
@@ -17,6 +17,9 @@ use std::fmt;
 
 mod functions;
 
+#[cfg(test)]
+mod tests;
+
 use crate::compiler::tokens::FStringSegment;
 use crate::{
     AddOp, Addition, AstNode, CelValue, ConditionalAnd, ConditionalOr, Expr, ExprList, Ident,

--- a/rscel/src/sql/mod.rs
+++ b/rscel/src/sql/mod.rs
@@ -1,0 +1,42 @@
+//! SQL compilation utilities.
+//!
+//! This module provides a minimal interface for converting CEL
+//! expressions into SQL fragments consisting of SQL text and a list
+//! of bound parameters.
+
+use crate::{AstNode, CelValue, Expr};
+
+/// SQL text and its associated parameter values.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SqlFragment {
+    /// The SQL text with placeholders for parameters.
+    pub sql: String,
+    /// Values bound to the placeholders within `sql`.
+    pub params: Vec<CelValue>,
+}
+
+/// Compiler that converts CEL AST nodes into SQL fragments.
+pub struct SqlCompiler;
+
+impl SqlCompiler {
+    /// Compile a CEL expression AST into a [`SqlFragment`].
+    pub fn compile(ast: &AstNode<Expr>) -> SqlFragment {
+        let compiler = SqlCompiler;
+        ast.to_sql(&compiler)
+    }
+}
+
+/// Trait for converting a type into a [`SqlFragment`].
+pub trait ToSql {
+    /// Convert `self` into a [`SqlFragment`] using the provided compiler.
+    fn to_sql(&self, compiler: &SqlCompiler) -> SqlFragment;
+}
+
+impl ToSql for AstNode<Expr> {
+    fn to_sql(&self, _compiler: &SqlCompiler) -> SqlFragment {
+        SqlFragment {
+            sql: String::new(),
+            params: Vec::new(),
+        }
+    }
+}

--- a/rscel/src/sql/tests/mod.rs
+++ b/rscel/src/sql/tests/mod.rs
@@ -1,0 +1,212 @@
+use super::*;
+use crate::{
+    AddOp, Addition, AstNode, CelValue, ConditionalAnd, ConditionalOr, Expr, ExprList, Ident,
+    LiteralsAndKeywords, Member, MemberPrime, MultOp, Multiplication, Primary, Relation,
+    SourceLocation, SourceRange, Unary,
+};
+
+fn sr() -> SourceRange {
+    SourceRange::new(SourceLocation::new(0, 0), SourceLocation::new(0, 0))
+}
+
+fn node<T>(v: T) -> AstNode<T> {
+    AstNode::new(v, sr())
+}
+
+fn primary_int(v: i64) -> AstNode<Primary> {
+    node(Primary::Literal(LiteralsAndKeywords::IntegerLit(v)))
+}
+
+fn primary_bool(v: bool) -> AstNode<Primary> {
+    node(Primary::Literal(LiteralsAndKeywords::BooleanLit(v)))
+}
+
+fn primary_ident(name: &str) -> AstNode<Primary> {
+    node(Primary::Ident(Ident(name.to_string())))
+}
+
+fn expr_from_member(m: AstNode<Member>) -> AstNode<Expr> {
+    let unary = node(Unary::Member(m));
+    let mul = node(Multiplication::Unary(unary));
+    let add = node(Addition::Unary(mul));
+    let rel = node(Relation::Unary(add));
+    let cand = node(ConditionalAnd::Unary(rel));
+    let cor = node(ConditionalOr::Unary(cand));
+    node(Expr::Unary(Box::new(cor)))
+}
+
+fn expr_from_primary(p: AstNode<Primary>) -> AstNode<Expr> {
+    expr_from_member(node(Member {
+        primary: p,
+        member: vec![],
+    }))
+}
+
+fn or_from_primary(p: AstNode<Primary>) -> AstNode<ConditionalOr> {
+    let member = node(Member {
+        primary: p,
+        member: vec![],
+    });
+    let unary = node(Unary::Member(member));
+    let mul = node(Multiplication::Unary(unary));
+    let add = node(Addition::Unary(mul));
+    let rel = node(Relation::Unary(add));
+    let cand = node(ConditionalAnd::Unary(rel));
+    node(ConditionalOr::Unary(cand))
+}
+
+fn relation_from_primary(p: AstNode<Primary>) -> AstNode<Relation> {
+    let member = node(Member {
+        primary: p,
+        member: vec![],
+    });
+    let unary = node(Unary::Member(member));
+    let mul = node(Multiplication::Unary(unary));
+    let add = node(Addition::Unary(mul));
+    node(Relation::Unary(add))
+}
+
+#[test]
+fn sql_arithmetic_from_ast() {
+    let lit1 = primary_int(1);
+    let lit2 = primary_int(2);
+    let lit3 = primary_int(3);
+
+    let mem1 = node(Member {
+        primary: lit1,
+        member: vec![],
+    });
+    let mem2 = node(Member {
+        primary: lit2,
+        member: vec![],
+    });
+    let mem3 = node(Member {
+        primary: lit3,
+        member: vec![],
+    });
+
+    let un1 = node(Unary::Member(mem1));
+    let un2 = node(Unary::Member(mem2));
+    let un3 = node(Unary::Member(mem3));
+
+    let mul2 = node(Multiplication::Unary(un2));
+    let mul_expr = node(Multiplication::Binary {
+        lhs: Box::new(mul2),
+        op: MultOp::Mult,
+        rhs: un3,
+    });
+
+    let mul1 = node(Multiplication::Unary(un1));
+    let add1 = node(Addition::Unary(mul1));
+    let add_expr = node(Addition::Binary {
+        lhs: Box::new(add1),
+        op: AddOp::Add,
+        rhs: mul_expr,
+    });
+
+    let rel = node(Relation::Unary(add_expr));
+    let cand = node(ConditionalAnd::Unary(rel));
+    let cor = node(ConditionalOr::Unary(cand));
+    let expr = node(Expr::Unary(Box::new(cor)));
+
+    let frag = SqlCompiler::compile(&expr).unwrap();
+    assert_eq!(frag.sql, "($1 + ($2 * $3))");
+    assert_eq!(
+        frag.params,
+        vec![
+            CelValue::from_int(1),
+            CelValue::from_int(2),
+            CelValue::from_int(3),
+        ],
+    );
+}
+
+#[test]
+fn sql_boolean_logic_from_ast() {
+    let rel_true = relation_from_primary(primary_bool(true));
+    let rel_false = relation_from_primary(primary_bool(false));
+    let rel_true2 = relation_from_primary(primary_bool(true));
+
+    let and_left = node(ConditionalAnd::Unary(rel_true));
+    let and_expr = node(ConditionalAnd::Binary {
+        lhs: Box::new(and_left),
+        rhs: rel_false,
+    });
+
+    let lhs_or = node(ConditionalOr::Unary(and_expr));
+    let rhs_or = node(ConditionalAnd::Unary(rel_true2));
+    let or_expr = node(ConditionalOr::Binary {
+        lhs: Box::new(lhs_or),
+        rhs: rhs_or,
+    });
+
+    let expr = node(Expr::Unary(Box::new(or_expr)));
+    let frag = SqlCompiler::compile(&expr).unwrap();
+    assert_eq!(frag.sql, "(($1 AND $2) OR $3)");
+    assert_eq!(
+        frag.params,
+        vec![
+            CelValue::from_bool(true),
+            CelValue::from_bool(false),
+            CelValue::from_bool(true),
+        ],
+    );
+}
+
+#[test]
+fn sql_ternary_from_ast() {
+    let cond = or_from_primary(primary_bool(true));
+    let true_clause = or_from_primary(primary_int(1));
+    let false_clause = expr_from_primary(primary_int(2));
+
+    let expr = node(Expr::Ternary {
+        condition: Box::new(cond),
+        true_clause: Box::new(true_clause),
+        false_clause: Box::new(false_clause),
+    });
+
+    let frag = SqlCompiler::compile(&expr).unwrap();
+    assert_eq!(frag.sql, "(CASE WHEN $1 THEN $2 ELSE $3 END)");
+    assert_eq!(
+        frag.params,
+        vec![
+            CelValue::from_bool(true),
+            CelValue::from_int(1),
+            CelValue::from_int(2),
+        ],
+    );
+}
+
+#[test]
+fn sql_member_access_from_ast() {
+    let primary = primary_ident("data");
+    let member_access = node(MemberPrime::MemberAccess {
+        ident: node(Ident("field".to_string())),
+    });
+    let member = node(Member {
+        primary,
+        member: vec![member_access],
+    });
+    let expr = expr_from_member(member);
+
+    let frag = SqlCompiler::compile(&expr).unwrap();
+    assert_eq!(frag.sql, "data ->> 'field'");
+    assert!(frag.params.is_empty());
+}
+
+#[test]
+fn sql_function_call_from_ast() {
+    let arg_expr = expr_from_primary(primary_int(1));
+    let call = node(ExprList {
+        exprs: vec![arg_expr],
+    });
+    let member = node(Member {
+        primary: primary_ident("abs"),
+        member: vec![node(MemberPrime::Call { call })],
+    });
+    let expr = expr_from_member(member);
+
+    let frag = SqlCompiler::compile(&expr).unwrap();
+    assert_eq!(frag.sql, "ABS($1)");
+    assert_eq!(frag.params, vec![CelValue::from_int(1)]);
+}

--- a/rscel/src/tests/mod.rs
+++ b/rscel/src/tests/mod.rs
@@ -1,5 +1,6 @@
 mod general_tests;
 mod neg_index_tests;
+mod sql_fn_tests;
 mod type_prop_tests;
 
 #[cfg(test_protos)]

--- a/rscel/src/tests/neg_index_tests.rs
+++ b/rscel/src/tests/neg_index_tests.rs
@@ -18,3 +18,14 @@ fn test_neg_index() {
         assert!(ctx.exec("test2", &bindings).is_err());
     }
 }
+
+#[test]
+fn test_neg_index_out_of_range() {
+    let mut ctx = CelContext::new();
+    let bindings = BindContext::new();
+
+    ctx.add_program_str("test", "[1,2,3][-4]")
+        .expect("Failed to compile program");
+
+    assert!(ctx.exec("test", &bindings).is_err());
+}

--- a/rscel/src/tests/sql_fn_tests.rs
+++ b/rscel/src/tests/sql_fn_tests.rs
@@ -1,0 +1,31 @@
+use crate::{CelContext, CelValue, SqlCompiler, SqlFragment};
+
+fn compile_sql(expr: &str) -> SqlFragment {
+    let mut ctx = CelContext::new();
+    ctx.add_program_str("test", expr).unwrap();
+    let prog = ctx.get_program("test").unwrap();
+    let ast = prog.details().ast().unwrap();
+    SqlCompiler::compile(ast)
+}
+
+#[test]
+fn sql_abs_function() {
+    let frag = compile_sql("abs(1)");
+    assert_eq!(frag.sql, "ABS($1)");
+    assert_eq!(frag.params, vec![CelValue::from_int(1)]);
+}
+
+#[test]
+fn sql_contains_function() {
+    let frag = compile_sql("contains('foobar', 'oba')");
+    assert_eq!(frag.sql, "($1 LIKE '%' || $2 || '%')");
+    assert_eq!(frag.params[0], CelValue::from_string("foobar".to_string()));
+    assert_eq!(frag.params[1], CelValue::from_string("oba".to_string()));
+}
+
+#[test]
+fn sql_get_full_year_function() {
+    let frag = compile_sql("getFullYear(ts)");
+    assert_eq!(frag.sql, "EXTRACT(YEAR FROM ts)");
+    assert!(frag.params.is_empty());
+}

--- a/rscel/src/tests/sql_fn_tests.rs
+++ b/rscel/src/tests/sql_fn_tests.rs
@@ -1,6 +1,6 @@
-use crate::{CelContext, CelValue, SqlCompiler, SqlFragment};
+use crate::{CelContext, CelValue, SqlCompiler, SqlError, SqlFragment};
 
-fn compile_sql(expr: &str) -> SqlFragment {
+fn compile_sql(expr: &str) -> Result<SqlFragment, SqlError> {
     let mut ctx = CelContext::new();
     ctx.add_program_str("test", expr).unwrap();
     let prog = ctx.get_program("test").unwrap();
@@ -10,14 +10,14 @@ fn compile_sql(expr: &str) -> SqlFragment {
 
 #[test]
 fn sql_abs_function() {
-    let frag = compile_sql("abs(1)");
+    let frag = compile_sql("abs(1)").unwrap();
     assert_eq!(frag.sql, "ABS($1)");
     assert_eq!(frag.params, vec![CelValue::from_int(1)]);
 }
 
 #[test]
 fn sql_contains_function() {
-    let frag = compile_sql("contains('foobar', 'oba')");
+    let frag = compile_sql("contains('foobar', 'oba')").unwrap();
     assert_eq!(frag.sql, "($1 LIKE '%' || $2 || '%')");
     assert_eq!(frag.params[0], CelValue::from_string("foobar".to_string()));
     assert_eq!(frag.params[1], CelValue::from_string("oba".to_string()));
@@ -25,7 +25,25 @@ fn sql_contains_function() {
 
 #[test]
 fn sql_get_full_year_function() {
-    let frag = compile_sql("getFullYear(ts)");
+    let frag = compile_sql("getFullYear(ts)").unwrap();
     assert_eq!(frag.sql, "EXTRACT(YEAR FROM ts)");
     assert!(frag.params.is_empty());
+}
+
+#[test]
+fn sql_unsupported_function_error() {
+    let err = compile_sql("unknownFunc(1)").unwrap_err();
+    match err {
+        SqlError::UnsupportedFeature(_) => {}
+        _ => panic!("unexpected error type"),
+    }
+}
+
+#[test]
+fn sql_invalid_property_access_error() {
+    let err = compile_sql("'str'.foo").unwrap_err();
+    match err {
+        SqlError::InvalidType(_) => {}
+        _ => panic!("unexpected error type"),
+    }
 }

--- a/rscel/src/types/cel_value.rs
+++ b/rscel/src/types/cel_value.rs
@@ -570,15 +570,23 @@ impl CelValue {
                                 }
                             } + (index as isize);
 
-                            if adjusted_index < 0
-                                || TryInto::<usize>::try_into(adjusted_index).unwrap() >= list.len()
-                            {
+                            let adjusted_index_usize =
+                                match TryInto::<usize>::try_into(adjusted_index) {
+                                    Ok(v) => v,
+                                    Err(_) => {
+                                        return CelValue::from_err(CelError::value(
+                                            "List access out of bounds 3",
+                                        ))
+                                    }
+                                };
+
+                            if adjusted_index < 0 || adjusted_index_usize >= list.len() {
                                 return CelValue::from_err(CelError::value(
                                     "List access out of bounds 3",
                                 ));
                             }
 
-                            list[adjusted_index as usize].clone()
+                            list[adjusted_index_usize].clone()
                         } else {
                             return CelValue::from_err(CelError::value(
                                 "Negative index is not allowed",

--- a/rscel/src/utils/scoped_counter.rs
+++ b/rscel/src/utils/scoped_counter.rs
@@ -1,45 +1,41 @@
-use std::cell::RefCell;
+use std::cell::Cell;
 
 pub struct ScopedCounter {
-    count: RefCell<usize>,
+    count: Cell<usize>,
 }
 
 pub struct ScopedCounterRef<'a> {
-    count: &'a RefCell<usize>,
+    count: &'a Cell<usize>,
 }
 
 impl ScopedCounter {
     pub fn new() -> ScopedCounter {
         ScopedCounter {
-            count: RefCell::new(0),
+            count: Cell::new(0),
         }
     }
 
     pub fn count(&self) -> usize {
-        *self.count.borrow()
+        self.count.get()
     }
 
     pub fn inc<'a>(&'a self) -> ScopedCounterRef<'a> {
-        {
-            let mut count = self.count.borrow_mut();
-
-            *count += 1;
-        }
+        let count = self.count.get();
+        self.count.set(count + 1);
         ScopedCounterRef { count: &self.count }
     }
 }
 
 impl<'a> ScopedCounterRef<'a> {
     pub fn count(&self) -> usize {
-        *self.count.borrow()
+        self.count.get()
     }
 }
 
 impl<'a> Drop for ScopedCounterRef<'a> {
     fn drop(&mut self) {
-        let mut count = self.count.borrow_mut();
-
-        *count -= 1;
+        let count = self.count.get();
+        self.count.set(count - 1);
     }
 }
 


### PR DESCRIPTION
This PR introduces a SQL compiler for the AST, including function registration, JSONB-based member access translation, structured error handling (SqlError), and comprehensive test coverage. It also optimizes interpreter performance by preallocating stacks, using Cell over RefCell, and leveraging Vec::with_capacity for argument vectors. Documentation has been expanded with contributor guidelines, SQL compilation examples, corrected spelling, and improved usage instructions. Additionally, repository metadata and a pyproject.toml have been added for Python packaging support.