### PR TITLE
Fix panic on `pyobject != null` (neq unreachable!)

### DIFF
--- a/python/src/cel_py_object.rs
+++ b/python/src/cel_py_object.rs
@@ -55,9 +55,6 @@ impl CelValueDyn for CelPyObject {
     }
 
     fn eq(&self, rhs: &CelValue) -> CelValue {
-        let lhs_type = self.as_type();
-        let rhs_type = self.as_type();
-
         if let CelValue::Dyn(rhs) = rhs {
             if let Some(rhs_obj) = rhs.any_ref().downcast_ref::<CelPyObject>() {
                 return Python::attach(|py| {
@@ -72,10 +69,11 @@ impl CelValueDyn for CelPyObject {
             }
         }
 
-        CelValue::from_err(CelError::invalid_op(&format!(
-            "Invalid op == between {} and {}",
-            lhs_type, rhs_type
-        )))
+        // A Python object is never equal to a non-Python-object value (e.g.
+        // null, an int, a string). Returning `false` rather than an error keeps
+        // `obj == null` / `obj != null` null-guards evaluating cleanly instead
+        // of surfacing a CelError (which previously panicked via neq()).
+        CelValue::from_bool(false)
     }
 
     fn is_truthy(&self) -> bool {

--- a/rscel/src/tests/general_tests.rs
+++ b/rscel/src/tests/general_tests.rs
@@ -864,3 +864,42 @@ fn test_match_captures_all() {
 
     assert_eq!(result, expected);
 }
+
+#[test]
+fn test_neq_propagates_dyn_eq_error() {
+    // Regression: neq() used to hit unreachable!() whenever eq() returned a
+    // non-Bool value (e.g. an Err from a Dyn type whose eq fails for the given
+    // rhs), which panicked the whole process. It must propagate the error
+    // instead. This is what surfaced as `pyobject != null` panicking in the
+    // python bindings.
+    #[derive(Debug)]
+    struct ErrOnEq;
+
+    impl std::fmt::Display for ErrOnEq {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "ErrOnEq")
+        }
+    }
+
+    impl crate::CelValueDyn for ErrOnEq {
+        fn as_type(&self) -> CelValue {
+            CelValue::from_type("ErrOnEq")
+        }
+        fn access(&self, _key: &str) -> CelValue {
+            CelValue::from_err(CelError::misc("no access"))
+        }
+        fn eq(&self, _rhs: &CelValue) -> CelValue {
+            CelValue::from_err(CelError::invalid_op("cannot compare ErrOnEq"))
+        }
+        fn is_truthy(&self) -> bool {
+            true
+        }
+        fn any_ref(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    let obj = CelValue::Dyn(Arc::new(ErrOnEq));
+    // Must not panic; the eq() error propagates out through neq().
+    assert!(obj.neq(CelValue::from_null()).is_err());
+}

--- a/rscel/src/types/cel_value.rs
+++ b/rscel/src/types/cel_value.rs
@@ -362,12 +362,11 @@ impl CelValue {
     }
 
     pub fn neq(self, rhs: CelValue) -> CelValue {
-        self.error_prop_or(rhs, |lhs, rhs| {
-            if let CelValue::Bool(res) = CelValueDyn::eq(&lhs, &rhs) {
-                return CelValue::from_bool(!res);
-            }
-
-            unreachable!();
+        self.error_prop_or(rhs, |lhs, rhs| match CelValueDyn::eq(&lhs, &rhs) {
+            CelValue::Bool(res) => CelValue::from_bool(!res),
+            // eq() can return an Err (e.g. a Dyn type whose eq fails for the
+            // given rhs). Propagate it instead of panicking via unreachable!().
+            other => other,
         })
     }
 

--- a/test/test_rscel.py
+++ b/test/test_rscel.py
@@ -36,6 +36,16 @@ def test_nested_obj():
     assert rscel.eval("f.foo.a", {"f": NestedClass()}) == "foo"
 
 
+def test_obj_neq_null():
+    # Regression: a bound Python object compared to null used to panic
+    # (neq() hit unreachable!() because CelPyObject::eq returned an error for
+    # `obj == null`). A Python object is never equal to null.
+    assert rscel.eval("e == null", {"e": TestIntWrapper(3)}) == False
+    assert rscel.eval("e != null", {"e": TestIntWrapper(3)}) == True
+    # Null-guard chains used by filters must short-circuit cleanly.
+    assert rscel.eval("e != null && e._val == 3", {"e": TestIntWrapper(3)}) == True
+
+
 def test_callable_arg():
     called = False
 


### PR DESCRIPTION
CelValue::neq assumed CelValueDyn::eq() always returns a Bool and called unreachable!() otherwise. When a Dyn value's eq() returns an Err (e.g. the python bindings' CelPyObject::eq, which errored for any non-pyobject rhs including null), neq() panicked the whole process — observed as `pyobject != null` crashing with 'internal error: entered unreachable code'.

- CelValue::neq now propagates a non-Bool eq() result instead of unreachable!().
- CelPyObject::eq returns false for a non-pyobject rhs, so `obj == null` is false and `obj != null` is true.

Tests:
- Rust: neq() propagates a Dyn eq() error instead of panicking.
- Python: `obj != null` / `obj == null` regression.